### PR TITLE
Fixed error prone example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ unless obfuscation is enabled in which case supply the obfuscated string values 
 
 
 ```
-authentication: # optional
-  obfuscation: # optional
-    key: key # the key you used to obfuscate using newrelic CLI
+# optional
+# authentication:
+#  obfuscation:
+#    key: key # the key you used to obfuscate using newrelic CLI
 credentials: # required
   account: replaceme
   user: replaceme


### PR DESCRIPTION
I provide context in #8 

Essentially, if you copy and paste the old `config.yam`l example ... It will try to obfuscate your code and lead to a super confusing network error because the obfuscation isn't configured. So you credentials never get passed.