### PR TITLE
adds SSO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ when obfuscating using the New Relic CLI. [Read the docs](https://github.com/new
 ### Credentials
 
 Credential values must be supplied for `account` (your Snowflake account identifier in the format `<account_locator>.<region_id>` or `<account_locator>.<region_id>.<cloud>` e.g. `xy12345.us-east-2`), `user`, `password` & `role` as plain-text strings, 
-unless obfuscation is enabled in which case supply the obfuscated string values for each property.
+unless obfuscation is enabled in which case supply the obfuscated string values for each property. `privateKey` must be supplied but can be kept as an empty string if useKeyPairAuth equals false, otherwise, `user` and `password` will be ignored and the private key used instead on connection handshake.
 
 
 ```
@@ -24,11 +24,13 @@ unless obfuscation is enabled in which case supply the obfuscated string values 
 #  obfuscation:
 #    key: key # the key you used to obfuscate using newrelic CLI
 credentials: # required
+  useKeyPairAuth: false
   account: replaceme
   user: replaceme
   password: replaceme
   role: replaceme
   warehouse: replaceme
+  privateKey: replaceme
 ```
 
 ## Installation

--- a/config.yaml
+++ b/config.yaml
@@ -2,8 +2,10 @@ authentication:
   obfuscation: # optional
     key: replaceme
 credentials:
+  useKeyPairAuth: false
   account: replaceme
   user: replaceme
   password: replaceme
   role: replaceme
   warehouse: replaceme
+  privateKey: replaceme

--- a/snowflake.js
+++ b/snowflake.js
@@ -75,8 +75,11 @@ const isDate = (date) => {
 let connection = null;
 if (useKeyPairAuth) {
   connection = snowflake.createConnection({
+    account: account,
     authenticator: "SNOWFLAKE_JWT",
-    privateKey: privateKey
+    privateKey: privateKey,
+    role: role,
+    warehouse: warehouse
   });
   // implement key pair auth
 } else {

--- a/snowflake.js
+++ b/snowflake.js
@@ -35,6 +35,7 @@ let password = '';
 let role = '';
 let warehouse = '';
 let useKeyPairAuth = false;
+let privateKey = '';
 
 if (config.authentication != null) {
 
@@ -47,6 +48,8 @@ if (config.authentication != null) {
       password = deobfuscate(config.credentials.password, key);
       role = deobfuscate(config.credentials.role, key);
       warehouse = deobfuscate(config.credentials.warehouse, key);
+      useKeyPairAuth = deobfuscate(config.credentials.useKeyPairAuth, key);
+      privateKey = deobfuscate(config.credentials.privateKey, key);
     }
   }
 
@@ -57,6 +60,8 @@ if (config.authentication != null) {
   password = config.credentials.password;
   role = config.credentials.role;
   warehouse = config.credentials.warehouse;
+  useKeyPairAuth = config.credentials.useKeyPairAuth;
+  privateKey = config.credentials.privateKey;
 } else {
   console.error('Invalid YAML file, please check format and try again');
   process.exit(0);
@@ -69,6 +74,10 @@ const isDate = (date) => {
 // Use Key Pair authentication or regular ol' user/pass to connect to Snowflake
 let connection = null;
 if (useKeyPairAuth) {
+  connection = snowflake.createConnection({
+    authenticator: "SNOWFLAKE_JWT",
+    privateKey: privateKey
+  });
   // implement key pair auth
 } else {
   connection = snowflake.createConnection({


### PR DESCRIPTION
Many Snowflake customers are protected by SSO. Initial support to SSO handshake using a JWT auth with a private key.