### PR TITLE
fix public/private key authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/newrelic/newrelic-snowflake-integration#readme",
   "dependencies": {
     "node-vault": "^0.9.21",
-    "snowflake-sdk": "^1.5.3",
+    "snowflake-sdk": "^1.6.7",
     "yaml": "^1.10.2"
   },
   "devDependencies": {

--- a/snowflake.js
+++ b/snowflake.js
@@ -48,7 +48,7 @@ if (config.authentication != null) {
       password = deobfuscate(config.credentials.password, key);
       role = deobfuscate(config.credentials.role, key);
       warehouse = deobfuscate(config.credentials.warehouse, key);
-      useKeyPairAuth = deobfuscate(config.credentials.useKeyPairAuth, key);
+      useKeyPairAuth = config.credentials.useKeyPairAuth;
       privateKey = deobfuscate(config.credentials.privateKey, key);
     }
   }
@@ -76,7 +76,9 @@ let connection = null;
 if (useKeyPairAuth) {
   connection = snowflake.createConnection({
     account: account,
-    authenticator: "SNOWFLAKE_JWT",
+    username: user,
+    password: password,
+    authenticator: "snowflake_jwt",
     privateKey: privateKey,
     role: role,
     warehouse: warehouse

--- a/snowflake.js
+++ b/snowflake.js
@@ -35,7 +35,7 @@ let password = '';
 let role = '';
 let warehouse = '';
 let useKeyPairAuth = false;
-let privateKey = '';
+let privateKeyPath = '';
 
 if (config.authentication != null) {
 
@@ -49,7 +49,7 @@ if (config.authentication != null) {
       role = deobfuscate(config.credentials.role, key);
       warehouse = deobfuscate(config.credentials.warehouse, key);
       useKeyPairAuth = config.credentials.useKeyPairAuth;
-      privateKey = deobfuscate(config.credentials.privateKey, key);
+      privateKeyPath = deobfuscate(config.credentials.privateKeyPath, key);
     }
   }
 
@@ -61,7 +61,7 @@ if (config.authentication != null) {
   role = config.credentials.role;
   warehouse = config.credentials.warehouse;
   useKeyPairAuth = config.credentials.useKeyPairAuth;
-  privateKey = config.credentials.privateKey;
+  privateKeyPath = config.credentials.privateKeyPath;
 } else {
   console.error('Invalid YAML file, please check format and try again');
   process.exit(0);
@@ -75,17 +75,17 @@ const isDate = (date) => {
 let connection = null;
 if (useKeyPairAuth) {
   connection = snowflake.createConnection({
+    authenticator: "snowflake_jwt",
     account: account,
     username: user,
-    password: password,
-    authenticator: "snowflake_jwt",
-    privateKey: privateKey,
+    privateKeyPath: privateKeyPath,
     role: role,
     warehouse: warehouse
   });
   // implement key pair auth
 } else {
   connection = snowflake.createConnection({
+    authenticator: "snowflake",
     account: account,
     username: user,
     password: password,


### PR DESCRIPTION
updates Snowflake SDK to 1.6.7 as there was a bug in 1.5.* branch with the connection parameters sanity check;
changes strategy to use a path to a private key file instead of pasting the key directly on config;
haven't pushed package-lock.json...

@jaesius , can you please help with package-lock? thanks.