### PR TITLE
Updating flex config for both macos and windows

### DIFF
--- a/flexConfigs/flex-snowflake-mac.yml
+++ b/flexConfigs/flex-snowflake-mac.yml
@@ -101,3 +101,21 @@ integrations:
             metric_type: snowflake.billing
           commands:
             - run: $$NEWRELIC_SNOWFLAKE_HOME/snowflakeintegration-macos $$NEWRELIC_SNOWFLAKE_HOME/config.yaml $$NEWRELIC_SNOWFLAKE_HOME/queries/warehouse_metering.sql
+        # Snowflake Warehouse Metering emits under a different event type - SnowflakeVirtualWarehouse
+        # since these metrics are related to a particular warehouse.
+        - name: longestQueries
+          entity: snowflake
+          event_type: SnowflakeVirtualWarehouse
+          custom_attributes:
+            metric_type: snowflake.query_performance
+          commands:
+            - run: $$NEWRELIC_SNOWFLAKE_HOME/snowflakeintegration-macos $$NEWRELIC_SNOWFLAKE_HOME/config.yaml $$NEWRELIC_SNOWFLAKE_HOME/queries/longest_queries.sql
+            # Snowflake Warehouse Metering emits under a different event type - SnowflakeVirtualWarehouse
+        # since these metrics are related to a particular warehouse.
+        - name: CreditUsageByWarehouse
+          entity: snowflake
+          event_type: SnowflakeVirtualWarehouse
+          custom_attributes:
+            metric_type: snowflake.credit_usage_by_warehouse
+          commands: 
+            - run: $$NEWRELIC_SNOWFLAKE_HOME/snowflakeintegration-macos $$NEWRELIC_SNOWFLAKE_HOME/config.yaml $$NEWRELIC_SNOWFLAKE_HOME/queries/credit_usage_by_warehouse.sql

--- a/flexConfigs/flex-snowflake-windows.yml
+++ b/flexConfigs/flex-snowflake-windows.yml
@@ -100,3 +100,21 @@ integrations:
             metric_type: snowflake.billing
           commands:
             - run: $$NEWRELIC_SNOWFLAKE_HOME\snowflakeintegration-win.exe $$NEWRELIC_SNOWFLAKE_HOME\config.yaml $$NEWRELIC_SNOWFLAKE_HOME\queries\warehouse_metering.sql
+        # Snowflake Warehouse Metering emits under a different event type - SnowflakeVirtualWarehouse
+        # since these metrics are related to a particular warehouse.
+        - name: longestQueries
+          entity: snowflake
+          event_type: SnowflakeVirtualWarehouse
+          custom_attributes:
+            metric_type: snowflake.query_performance
+          commands:
+            - run: $$NEWRELIC_SNOWFLAKE_HOME\snowflakeintegration-win.exe $$NEWRELIC_SNOWFLAKE_HOME\config.yaml $$NEWRELIC_SNOWFLAKE_HOME\queries\longest_queries.sql
+            # Snowflake Warehouse Metering emits under a different event type - SnowflakeVirtualWarehouse
+        # since these metrics are related to a particular warehouse.
+        - name: CreditUsageByWarehouse
+          entity: snowflake
+          event_type: SnowflakeVirtualWarehouse
+          custom_attributes:
+            metric_type: snowflake.credit_usage_by_warehouse
+          commands: 
+            - run: $$NEWRELIC_SNOWFLAKE_HOME\snowflakeintegration-win.exe $$NEWRELIC_SNOWFLAKE_HOME\config.yaml $$NEWRELIC_SNOWFLAKE_HOME\queries\credit_usage_by_warehouse.sql


### PR DESCRIPTION
Hi @jaesius 
I updated the flex config file for both macos  and windows.
As in this PR(https://github.com/newrelic/newrelic-snowflake-integration/pull/36), I added two new queries i.e, longestQueries and creditsUsageByWarehouse and updated flexConfig/flex-snowflake-linux.yml for that queries to work.
Now I updated the flexConfig/flex-snowflake-linux.yml  and flexConfig/flex-snowflake-linux.yml  for the new queries which was added before, So the new queries will work for linux/macos/windows.